### PR TITLE
Switch Docker base image to upload-validator-base-alpine:18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM humancellatlas/upload-validator-base-alpine:17
+FROM humancellatlas/upload-validator-base-alpine:18
 
 LABEL maintainer="nuno.fonseca at gmail.com"
 


### PR DESCRIPTION
Upload's libraries have changes somewhat and this keep the validators in line with the current versions.