### PR TITLE
Bump version of upload validator base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM humancellatlas/upload-validator-base-alpine:19
+FROM humancellatlas/upload-validator-base-alpine:21
 
 LABEL maintainer="nuno.fonseca at gmail.com"
 


### PR DESCRIPTION
Reflects newest change in upload-service that sends subprocess logs to a file instead of STDOUT/STDERR