### PR TITLE
fix for large file validation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM humancellatlas/upload-validator-base-alpine:21
+FROM humancellatlas/upload-validator-base-alpine:22
 
 LABEL maintainer="nuno.fonseca at gmail.com"
 

--- a/wrapper/validator/validator.py
+++ b/wrapper/validator/validator.py
@@ -8,12 +8,11 @@ class Validator:
         report = ValidationReport()
 
         process = subprocess.Popen(["fastq_info", "-r", "-s", file_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        process.wait()
-        err_lines = process.stderr.readlines()
+        stdout, stderr = process.communicate()
+        err_lines = stderr.decode().split('\n')
         for line in err_lines:
-            line_str = line.decode("utf-8")
-            if "ERROR" in line_str:
-                report.log_error(line_str.rstrip())
+            if "ERROR" in line:
+                report.log_error(line.rstrip())
 
         report.state = "INVALID" if report.errors else "VALID"
 


### PR DESCRIPTION
This PR has 2 changes

1) Updates from subprocess.wait() to subprocess.communicate() to fix hanging subprocess for large file validations. Note the following from https://docs.python.org/2/library/subprocess.html: process.wait() will deadlock when using stdout=PIPE and/or stderr=PIPE and the child process generates enough output to a pipe such that it blocks waiting for the OS pipe buffer to accept more data. Use communicate() to avoid that.

2) update to latest base validator harness 