### PR TITLE
Handle any exception that may occur during fastq validation to make su…

### DIFF
--- a/wrapper/validator/validator.py
+++ b/wrapper/validator/validator.py
@@ -7,12 +7,15 @@ class Validator:
     def validate(self, file_path):
         report = ValidationReport()
 
-        process = subprocess.Popen(["fastq_info", "-r", "-s", file_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        stdout, stderr = process.communicate()
-        err_lines = stderr.decode().split('\n')
-        for line in err_lines:
-            if "ERROR" in line:
-                report.log_error(line.rstrip())
+        try:
+            process = subprocess.Popen(["fastq_info", "-r", "-s", file_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            stdout, stderr = process.communicate()
+            err_lines = stderr.decode().split('\n')
+            for line in err_lines:
+                if "ERROR" in line:
+                    report.log_error(line.rstrip())
+        except (TypeError, ValueError, Exception) as e:
+            report.log_error(e)
 
         report.state = "INVALID" if report.errors else "VALID"
 

--- a/wrapper/validator/validator.py
+++ b/wrapper/validator/validator.py
@@ -8,7 +8,7 @@ class Validator:
         report = ValidationReport()
 
         try:
-            process = subprocess.Popen(["fastq_info", "-r", "-s", file_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            process = subprocess.Popen(["fastq_info000", "-r", "-s", file_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             stdout, stderr = process.communicate()
             err_lines = stderr.decode().split('\n')
             for line in err_lines:

--- a/wrapper/validator/validator.py
+++ b/wrapper/validator/validator.py
@@ -8,7 +8,7 @@ class Validator:
         report = ValidationReport()
 
         try:
-            process = subprocess.Popen(["fastq_info000", "-r", "-s", file_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            process = subprocess.Popen(["fastq_info", "-r", "-s", file_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             stdout, stderr = process.communicate()
             err_lines = stderr.decode().split('\n')
             for line in err_lines:

--- a/wrapper/validator/validator.py
+++ b/wrapper/validator/validator.py
@@ -15,7 +15,7 @@ class Validator:
                 if "ERROR" in line:
                     report.log_error(line.rstrip())
         except (TypeError, ValueError, Exception) as e:
-            report.log_error(e)
+            report.log_error(str(e))
 
         report.state = "INVALID" if report.errors else "VALID"
 


### PR DESCRIPTION
Spawning the subprocess may raise an exception which isn't being handled causing an unexpected string in stdout in fileValidationResult. Part of the fix for [#448](https://github.com/HumanCellAtlas/ingest-central/issues/448)